### PR TITLE
Support more field of metadata when create `comicInfo`

### DIFF
--- a/binding.go
+++ b/binding.go
@@ -12,3 +12,25 @@ var AllMangaValue = []struct {
 	{comicinfo.Manga_Yes, "Yes"},
 	{comicinfo.Manga_YesAndRightToLeft, "YesAndRightToLeft"},
 }
+
+// The value of `AgeRating` const to use in wails binding.
+var AllAgeRatingValue = []struct {
+	Value  comicinfo.AgeRating
+	TSName string
+}{
+	{comicinfo.AgeRating_Unknown, "Unknown"},
+	{comicinfo.AgeRating_AdultsOnly18, "AdultsOnly18"},
+	{comicinfo.AgeRating_EarlyChildhood, "EarlyChildhood"},
+	{comicinfo.AgeRating_Everyone, "Everyone"},
+	{comicinfo.AgeRating_Everyone10Plus, "Everyone10Plus"},
+	{comicinfo.AgeRating_G, "G"},
+	{comicinfo.AgeRating_KidsToAdults, "KidsToAdults"},
+	{comicinfo.AgeRating_M, "M"},
+	{comicinfo.AgeRating_MA15Plus, "MA15Plus"},
+	{comicinfo.AgeRating_Mature17Plus, "Mature17Plus"},
+	{comicinfo.AgeRating_PG, "PG"},
+	{comicinfo.AgeRating_R18Plus, "R18Plus"},
+	{comicinfo.AgeRating_RatingPending, "RatingPending"},
+	{comicinfo.AgeRating_Teen, "Teen"},
+	{comicinfo.AgeRating_X18Plus, "X18Plus"},
+}

--- a/binding.go
+++ b/binding.go
@@ -1,0 +1,14 @@
+package main
+
+import "gui-comicinfo/internal/comicinfo"
+
+// The value of `Manga` const to use in wails binding.
+var AllMangaValue = []struct {
+	Value  comicinfo.Manga
+	TSName string
+}{
+	{comicinfo.Manga_Unknown, "Unknown"},
+	{comicinfo.Manga_No, "No"},
+	{comicinfo.Manga_Yes, "Yes"},
+	{comicinfo.Manga_YesAndRightToLeft, "YesAndRightToLeft"},
+}

--- a/frontend/src/components/EnumSelect.tsx
+++ b/frontend/src/components/EnumSelect.tsx
@@ -1,37 +1,44 @@
 import { Form } from "react-bootstrap";
 import { comicinfo } from "../../wailsjs/go/models";
 
-type props = {
+/** Props for `EnumOptions` */
+type OptionProps = {
+	/** Both displayed value & actual value for `<option>`. */
 	value: string | undefined;
 };
 
-function MangaOptions({ value }: props) {
+/** JSX element for `<option>`, designed to hold enum value. */
+function EnumOptions({ value }: OptionProps) {
 	return <option value={value}>{value}</option>;
 }
 
-type MangaSelectProps = {
+/** Props for select box. */
+type EnumSelectProps = {
+	/** Current value of input field. */
 	value: string | undefined;
 	/** Handle value change of input field. */
 	onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
 };
 
-export function MangaSelect({ value, onChange }: MangaSelectProps) {
+/** Form Select Element specified for `Manga` enum. */
+export function MangaSelect({ value, onChange }: EnumSelectProps) {
 	return (
 		<Form.Select value={value} title="Manga" onChange={onChange}>
 			<option value={""}></option>
 			{Object.values(comicinfo.Manga).map((item) => (
-				<MangaOptions value={item} />
+				<EnumOptions value={item} />
 			))}
 		</Form.Select>
 	);
 }
 
-export function AgeRatingSelect({ value, onChange }: MangaSelectProps) {
+/** Form Select Element specified for `AgeRating` enum. */
+export function AgeRatingSelect({ value, onChange }: EnumSelectProps) {
 	return (
 		<Form.Select value={value} title="AgeRating" onChange={onChange}>
 			<option value={""}></option>
 			{Object.values(comicinfo.AgeRating).map((item) => (
-				<MangaOptions value={item} />
+				<EnumOptions value={item} />
 			))}
 		</Form.Select>
 	);

--- a/frontend/src/components/specificVal.tsx
+++ b/frontend/src/components/specificVal.tsx
@@ -19,7 +19,18 @@ export function MangaSelect({ value, onChange }: MangaSelectProps) {
 	return (
 		<Form.Select value={value} title="Manga" onChange={onChange}>
 			<option value={""}></option>
-			{Object.keys(comicinfo.Manga).map((item) => (
+			{Object.values(comicinfo.Manga).map((item) => (
+				<MangaOptions value={item} />
+			))}
+		</Form.Select>
+	);
+}
+
+export function AgeRatingSelect({ value, onChange }: MangaSelectProps) {
+	return (
+		<Form.Select value={value} title="AgeRating" onChange={onChange}>
+			<option value={""}></option>
+			{Object.values(comicinfo.AgeRating).map((item) => (
 				<MangaOptions value={item} />
 			))}
 		</Form.Select>

--- a/frontend/src/components/specificVal.tsx
+++ b/frontend/src/components/specificVal.tsx
@@ -1,0 +1,27 @@
+import { Form } from "react-bootstrap";
+import { comicinfo } from "../../wailsjs/go/models";
+
+type props = {
+	value: string | undefined;
+};
+
+function MangaOptions({ value }: props) {
+	return <option value={value}>{value}</option>;
+}
+
+type MangaSelectProps = {
+	value: string | undefined;
+	/** Handle value change of input field. */
+	onChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+};
+
+export function MangaSelect({ value, onChange }: MangaSelectProps) {
+	return (
+		<Form.Select value={value} title="Manga" onChange={onChange}>
+			<option value={""}></option>
+			{Object.keys(comicinfo.Manga).map((item) => (
+				<MangaOptions value={item} />
+			))}
+		</Form.Select>
+	);
+}

--- a/frontend/src/formRow.tsx
+++ b/frontend/src/formRow.tsx
@@ -60,7 +60,7 @@ type FormRowProps = {
 	/** the type of input, same with HTML input type */
 	inputType?: string;
 	/** current inputted value */
-	value?: string;
+	value?: string | number;
 	/** number of row of textarea */
 	textareaRow?: number | undefined;
 	/** determines whether the input is disabled */
@@ -71,6 +71,11 @@ type FormRowProps = {
 
 /**
  * Create a uniform Form.Group Element as Row.
+ *
+ * There has some special handling for `number` values:
+ * - When `value == 0`, display empty string instead of `0`
+ * - input type of this element will force to `number`
+ *
  * @returns A Row Element, Contains one input group with label.
  */
 export function FormRow({ title, inputType, value, textareaRow, disabled, onChange }: FormRowProps) {
@@ -82,8 +87,8 @@ export function FormRow({ title, inputType, value, textareaRow, disabled, onChan
 			<Col sm="9">
 				<Form.Control
 					as={textareaRow != undefined ? "textarea" : undefined}
-					type={inputType}
-					value={value}
+					type={typeof value == "number" ? "number" : inputType}
+					value={typeof value == "number" && value == 0 ? "" : value}
 					title={title}
 					onChange={onChange}
 					rows={textareaRow != undefined ? textareaRow : 1}

--- a/frontend/src/formRow.tsx
+++ b/frontend/src/formRow.tsx
@@ -159,3 +159,19 @@ export function FormDateRow({ title, year, month, day, disabled, onYearChange, o
 		</Form.Group>
 	);
 }
+
+type FormSelectRowProps = {
+	title: string;
+	selectElement: JSX.Element;
+};
+
+export function FormSelectRow({ title, selectElement }: FormSelectRowProps) {
+	return (
+		<Form.Group as={Row} className="mb-3">
+			<Form.Label column sm="2">
+				{title}
+			</Form.Label>
+			<Col sm="9">{selectElement}</Col>
+		</Form.Group>
+	);
+}

--- a/frontend/src/formRow.tsx
+++ b/frontend/src/formRow.tsx
@@ -160,11 +160,18 @@ export function FormDateRow({ title, year, month, day, disabled, onYearChange, o
 	);
 }
 
+/** Props for `FormSelectRow`. */
 type FormSelectRowProps = {
+	/** the title/label of this input group */
 	title: string;
+	/** The JSX.Element of `<select>`. */
 	selectElement: JSX.Element;
 };
 
+/**
+ * Create a uniform Form.Group Element as Row.
+ * This element specify designed for select element.
+ */
 export function FormSelectRow({ title, selectElement }: FormSelectRowProps) {
 	return (
 		<Form.Group as={Row} className="mb-3">

--- a/frontend/src/pages/inputPanel.tsx
+++ b/frontend/src/pages/inputPanel.tsx
@@ -80,15 +80,27 @@ function CreatorMetadata({ comicInfo: info, dataHandler }: MetadataProps) {
 	);
 }
 
+/** The user interface for show/edit Series MetaData. */
+function SeriesMetadata({ comicInfo, dataHandler }: MetadataProps) {
+	return (
+		<div>
+			<Form>
+				<FormRow title={"Series"} value={comicInfo?.Series} onChange={dataHandler} />
+				<FormRow title={"Volume"} value={comicInfo?.Volume} onChange={dataHandler} />
+				<FormRow title={"Count"} value={comicInfo?.Count} onChange={dataHandler} />
+				<FormRow title={"AgeRating"} value={comicInfo?.AgeRating} onChange={dataHandler} />
+				<FormRow title={"Manga"} value={comicInfo?.Manga} onChange={dataHandler} />
+				<FormRow title={"Genre"} value={comicInfo?.Genre} onChange={dataHandler} />
+				<FormRow title={"LanguageISO"} value={comicInfo?.LanguageISO} onChange={dataHandler} />
+			</Form>
+		</div>
+	);
+}
+
 /** The Props for Tag Metadata Component. */
 type TagMetadataProps = {
 	/** The comic info object. Accept undefined value. */
 	comicInfo: comicinfo.ComicInfo | undefined;
-
-	// TODO: Remove dataHandler after the tags can be add/remove by other components except human modify
-
-	/** The method called when input field value is changed. */
-	dataHandler: (e: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLSelectElement>) => void;
 
 	/** The info Setter. This function should be doing setting value, but no verification. */
 	infoSetter: (field: string, value: string | number) => void;
@@ -98,7 +110,7 @@ type TagMetadataProps = {
  * The interface for show/edit tags metadata.
  * @returns JSX Element
  */
-function TagMetadata({ comicInfo: info, dataHandler, infoSetter }: TagMetadataProps) {
+function TagMetadata({ comicInfo: info, infoSetter }: TagMetadataProps) {
 	/** Hooks of tag that to be added. Only allow single tag to be added at a time. */
 	const [singleTag, setSingleTag] = useState<string>("");
 
@@ -249,8 +261,13 @@ export default function InputPanel({ comicInfo, exportFunc, infoSetter }: InputP
 				<Tab eventKey="Creator" title="Creator">
 					<CreatorMetadata comicInfo={comicInfo} dataHandler={handleChanges} />
 				</Tab>
+
 				<Tab eventKey="Tags" title="Tags">
-					<TagMetadata comicInfo={comicInfo} dataHandler={handleChanges} infoSetter={infoSetter} />
+					<TagMetadata comicInfo={comicInfo} infoSetter={infoSetter} />
+				</Tab>
+
+				<Tab eventKey="Series" title="Series">
+					<SeriesMetadata comicInfo={comicInfo} dataHandler={handleChanges} />
 				</Tab>
 			</Tabs>
 

--- a/frontend/src/pages/inputPanel.tsx
+++ b/frontend/src/pages/inputPanel.tsx
@@ -10,7 +10,7 @@ import Tabs from "react-bootstrap/Tabs";
 import { comicinfo } from "../../wailsjs/go/models";
 import { TagsArea } from "../components/Tags";
 import { FormDateRow, FormRow, FormSelectRow } from "../formRow";
-import { AgeRatingSelect, MangaSelect } from "../components/specificVal";
+import { AgeRatingSelect, MangaSelect } from "../components/EnumSelect";
 
 /** Props Interface for InputPanel */
 type InputProps = {

--- a/frontend/src/pages/inputPanel.tsx
+++ b/frontend/src/pages/inputPanel.tsx
@@ -9,7 +9,8 @@ import Tabs from "react-bootstrap/Tabs";
 // Project Specified Component
 import { comicinfo } from "../../wailsjs/go/models";
 import { TagsArea } from "../components/Tags";
-import { FormDateRow, FormRow } from "../formRow";
+import { FormDateRow, FormRow, FormSelectRow } from "../formRow";
+import { MangaSelect } from "../components/specificVal";
 
 /** Props Interface for InputPanel */
 type InputProps = {
@@ -89,7 +90,10 @@ function SeriesMetadata({ comicInfo, dataHandler }: MetadataProps) {
 				<FormRow title={"Volume"} value={comicInfo?.Volume} onChange={dataHandler} />
 				<FormRow title={"Count"} value={comicInfo?.Count} onChange={dataHandler} />
 				<FormRow title={"AgeRating"} value={comicInfo?.AgeRating} onChange={dataHandler} />
-				<FormRow title={"Manga"} value={comicInfo?.Manga} onChange={dataHandler} />
+				<FormSelectRow
+					title={"Manga"}
+					selectElement={<MangaSelect value={comicInfo?.Manga} onChange={dataHandler} />}
+				/>
 				<FormRow title={"Genre"} value={comicInfo?.Genre} onChange={dataHandler} />
 				<FormRow title={"LanguageISO"} value={comicInfo?.LanguageISO} onChange={dataHandler} />
 			</Form>

--- a/frontend/src/pages/inputPanel.tsx
+++ b/frontend/src/pages/inputPanel.tsx
@@ -10,7 +10,7 @@ import Tabs from "react-bootstrap/Tabs";
 import { comicinfo } from "../../wailsjs/go/models";
 import { TagsArea } from "../components/Tags";
 import { FormDateRow, FormRow, FormSelectRow } from "../formRow";
-import { MangaSelect } from "../components/specificVal";
+import { AgeRatingSelect, MangaSelect } from "../components/specificVal";
 
 /** Props Interface for InputPanel */
 type InputProps = {
@@ -89,7 +89,10 @@ function SeriesMetadata({ comicInfo, dataHandler }: MetadataProps) {
 				<FormRow title={"Series"} value={comicInfo?.Series} onChange={dataHandler} />
 				<FormRow title={"Volume"} value={comicInfo?.Volume} onChange={dataHandler} />
 				<FormRow title={"Count"} value={comicInfo?.Count} onChange={dataHandler} />
-				<FormRow title={"AgeRating"} value={comicInfo?.AgeRating} onChange={dataHandler} />
+				<FormSelectRow
+					title={"AgeRating"}
+					selectElement={<AgeRatingSelect value={comicInfo?.AgeRating} onChange={dataHandler} />}
+				/>
 				<FormSelectRow
 					title={"Manga"}
 					selectElement={<MangaSelect value={comicInfo?.Manga} onChange={dataHandler} />}

--- a/frontend/src/pages/inputPanel.tsx
+++ b/frontend/src/pages/inputPanel.tsx
@@ -97,6 +97,22 @@ function SeriesMetadata({ comicInfo, dataHandler }: MetadataProps) {
 	);
 }
 
+/** The user interface for show/edit Collection & ReadList MetaData. */
+function MiscMetadata({ comicInfo, dataHandler }: MetadataProps) {
+	return (
+		<div>
+			<Form>
+				<FormRow title={"SeriesGroup"} value={comicInfo?.SeriesGroup} onChange={dataHandler} />
+				<FormRow title={"AlternateSeries"} value={comicInfo?.AlternateSeries} onChange={dataHandler} />
+				<FormRow title={"AlternateNumber "} value={comicInfo?.AlternateNumber} onChange={dataHandler} />
+				<FormRow title={"AlternateCount"} value={comicInfo?.AlternateCount} onChange={dataHandler} />
+				<FormRow title={"StoryArc"} value={comicInfo?.StoryArc} onChange={dataHandler} />
+				<FormRow title={"StoryArcNumber"} value={comicInfo?.StoryArcNumber} onChange={dataHandler} />
+			</Form>
+		</div>
+	);
+}
+
 /** The Props for Tag Metadata Component. */
 type TagMetadataProps = {
 	/** The comic info object. Accept undefined value. */
@@ -268,6 +284,10 @@ export default function InputPanel({ comicInfo, exportFunc, infoSetter }: InputP
 
 				<Tab eventKey="Series" title="Series">
 					<SeriesMetadata comicInfo={comicInfo} dataHandler={handleChanges} />
+				</Tab>
+
+				<Tab eventKey="Misc" title="Collection & ReadList">
+					<MiscMetadata comicInfo={comicInfo} dataHandler={handleChanges} />
 				</Tab>
 			</Tabs>
 

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1,5 +1,11 @@
 export namespace comicinfo {
 	
+	export enum Manga {
+	    Unknown = "Unknown",
+	    No = "No",
+	    Yes = "Yes",
+	    YesAndRightToLeft = "YesAndRightToLeft",
+	}
 	export class ComicPageInfo {
 	    Image: number;
 	    Type: string;
@@ -73,7 +79,7 @@ export namespace comicinfo {
 	    Format: string;
 	    AgeRating: string;
 	    BlackAndWhite: string;
-	    Manga: string;
+	    Manga: Manga;
 	    Characters: string;
 	    Teams: string;
 	    Locations: string;

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -6,6 +6,23 @@ export namespace comicinfo {
 	    Yes = "Yes",
 	    YesAndRightToLeft = "YesAndRightToLeft",
 	}
+	export enum AgeRating {
+	    Unknown = "Unknown",
+	    AdultsOnly18 = "Adults Only 18+",
+	    EarlyChildhood = "Early Childhood",
+	    Everyone = "Everyone",
+	    Everyone10Plus = "Everyone 10+",
+	    G = "G",
+	    KidsToAdults = "Kids to Adults",
+	    M = "M",
+	    MA15Plus = "MA15+",
+	    Mature17Plus = "Mature 17+",
+	    PG = "PG",
+	    R18Plus = "R18+",
+	    RatingPending = "Rating Pending",
+	    Teen = "Teen",
+	    X18Plus = "X18+",
+	}
 	export class ComicPageInfo {
 	    Image: number;
 	    Type: string;
@@ -77,7 +94,7 @@ export namespace comicinfo {
 	    PageCount: number;
 	    LanguageISO: string;
 	    Format: string;
-	    AgeRating: string;
+	    AgeRating: AgeRating;
 	    BlackAndWhite: string;
 	    Manga: Manga;
 	    Characters: string;

--- a/main.go
+++ b/main.go
@@ -28,6 +28,9 @@ func main() {
 		Bind: []interface{}{
 			app,
 		},
+		EnumBind: []interface{}{
+			AllMangaValue,
+		},
 	})
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 		},
 		EnumBind: []interface{}{
 			AllMangaValue,
+			AllAgeRatingValue,
 		},
 	})
 


### PR DESCRIPTION
### Changes (New Feature)

- Add panel to edit Series metadata
- Add panel to edit Collection & Read List metadata
- Add support for `<select>` element in `formRow`
- Add support for `number` value in `FormRow` element

### Notes (If any)

Enum Binding has been added to `wails` through `binding.go` file.

### Related Issues

Close #36 , Close #39.

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have add new feature description to README.md of this repository
-   [x] I have add/modify file description to README.md of the package (if any)

#### Testing Checklist:

-   [x] I have create new test case / test for new feature
-   [x] I have run all new & existing test and pass locally with my changes
