### PR TITLE
Show folder name when edit `comicInfo`

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -185,6 +185,10 @@ function App() {
 							// Perform Mode subtraction
 							let temp = Math.min(mode + 1, mode_export);
 
+							// Clear user input
+							setInfo(undefined);
+							setInputDir(undefined);
+
 							// Set Mode
 							setMode(temp);
 						}}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
 	/** The ComicInfo model. For communicate with different panel. */
 	const [info, setInfo] = useState<comicinfo.ComicInfo | undefined>(undefined);
 
-	/** The directory of initial input, which is the folder contain image1. */
+	/** The directory of initial input, which is the folder contain image. */
 	const [inputDir, setInputDir] = useState<string | undefined>(undefined);
 
 	/**
@@ -165,7 +165,12 @@ function App() {
 				<Col>
 					{mode == mode_select_folder && <FolderSelect processFunc={passingFolder} />}
 					{mode == mode_input_data && (
-						<InputPanel comicInfo={info} exportFunc={showExportPanel} infoSetter={infoSetter} />
+						<InputPanel
+							comicInfo={info}
+							exportFunc={showExportPanel}
+							infoSetter={infoSetter}
+							folderName={inputDir}
+						/>
 					)}
 					{mode == mode_export && (
 						<ExportPanel comicInfo={info} originalDirectory={inputDir} backToHomeFunc={backToHomePanel} />

--- a/frontend/src/filename.tsx
+++ b/frontend/src/filename.tsx
@@ -1,0 +1,28 @@
+/**
+ * This file contains filename utilities.
+ */
+
+/** Function for get basename in absolute path. */
+export const basename = function (absPath: string): string {
+	const temp = (" " + absPath).slice(1);
+
+	if (temp.split("\\") == undefined) {
+		return "";
+	}
+
+	const strParts = temp.split("\\").pop();
+	if (strParts === undefined) {
+		return "";
+	}
+
+	if (strParts.split("/") === undefined) {
+		return "";
+	}
+
+	const strParts2 = strParts.split("/").pop();
+	if (strParts2 === undefined) {
+		return "";
+	}
+
+	return strParts2;
+};

--- a/frontend/src/filename.tsx
+++ b/frontend/src/filename.tsx
@@ -2,8 +2,15 @@
  * This file contains filename utilities.
  */
 
-/** Function for get basename in absolute path. */
-export const basename = function (absPath: string): string {
+/**
+ * Function for get basename in absolute path, or empty string if error occurs.
+ *
+ * Basename is retrieved by delete any prefix up to the last slash ('/') character and return the result.
+ *
+ * @param absPath absolute path of folder/file
+ * @returns basename of absolute path, or empty string if any error occurred
+ */
+export function basename(absPath: string): string {
 	const temp = (" " + absPath).slice(1);
 
 	if (temp.split("\\") == undefined) {
@@ -25,4 +32,4 @@ export const basename = function (absPath: string): string {
 	}
 
 	return strParts2;
-};
+}

--- a/frontend/src/formRow.tsx
+++ b/frontend/src/formRow.tsx
@@ -57,6 +57,8 @@ export function RangeSelect({ min, max, value, title, disabled, onChange }: Rang
 type FormRowProps = {
 	/** the title/label of this input group */
 	title: string;
+	/** Class name for label. Can be used in styling. */
+	titleClass?: string;
 	/** the type of input, same with HTML input type */
 	inputType?: string;
 	/** current inputted value */
@@ -78,10 +80,10 @@ type FormRowProps = {
  *
  * @returns A Row Element, Contains one input group with label.
  */
-export function FormRow({ title, inputType, value, textareaRow, disabled, onChange }: FormRowProps) {
+export function FormRow({ title, titleClass, inputType, value, textareaRow, disabled, onChange }: FormRowProps) {
 	return (
 		<Form.Group as={Row} className="mb-3">
-			<Form.Label column sm="2">
+			<Form.Label column sm="2" className={titleClass != undefined ? titleClass : ""}>
 				{title}
 			</Form.Label>
 			<Col sm="9">

--- a/frontend/src/pages/inputPanel.tsx
+++ b/frontend/src/pages/inputPanel.tsx
@@ -11,11 +11,15 @@ import { comicinfo } from "../../wailsjs/go/models";
 import { TagsArea } from "../components/Tags";
 import { FormDateRow, FormRow, FormSelectRow } from "../formRow";
 import { AgeRatingSelect, MangaSelect } from "../components/EnumSelect";
+import { basename } from "../filename";
 
 /** Props Interface for InputPanel */
 type InputProps = {
 	/** The comic info object. Accept undefined value. */
 	comicInfo: comicinfo.ComicInfo | undefined;
+
+	/** The folder name for reference. */
+	folderName?: string;
 
 	/** The function to change display panel to export panel. */
 	exportFunc: () => void;
@@ -240,7 +244,7 @@ function TagMetadata({ comicInfo: info, infoSetter }: TagMetadataProps) {
  * The panel for input/edit content of ComicInfo.xml
  * @returns JSX Element
  */
-export default function InputPanel({ comicInfo, exportFunc, infoSetter }: InputProps) {
+export default function InputPanel({ comicInfo, folderName, exportFunc, infoSetter }: InputProps) {
 	/**
 	 * Handler for all input field in this panel.
 	 * This method will use <code>infoSetter</code> as core,
@@ -274,6 +278,12 @@ export default function InputPanel({ comicInfo, exportFunc, infoSetter }: InputP
 	return (
 		<div id="Input-Panel" className="mt-5">
 			<h5 className="mb-4">Modify ComicInfo.xml</h5>
+			<FormRow
+				title={"Folder Name"}
+				titleClass="fst-italic"
+				value={folderName != undefined ? basename(folderName) : "(N/A)"}
+				disabled
+			/>
 
 			{/* The Tabs Group to display metadata. */}
 			<Tabs defaultActiveKey="Main" id="uncontrolled-tab-example" className="mb-3">

--- a/frontend/src/pages/inputPanel.tsx
+++ b/frontend/src/pages/inputPanel.tsx
@@ -278,6 +278,8 @@ export default function InputPanel({ comicInfo, folderName, exportFunc, infoSett
 	return (
 		<div id="Input-Panel" className="mt-5">
 			<h5 className="mb-4">Modify ComicInfo.xml</h5>
+
+			{/* Component for showing folder name (with basename only) */}
 			<FormRow
 				title={"Folder Name"}
 				titleClass="fst-italic"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module gui-comicinfo
 
-go 1.22
+go 1.22.0
 
 require github.com/wailsapp/wails/v2 v2.8.0
 


### PR DESCRIPTION
### Changes

- Add display for folder name in edit comicInfo, allow user to trace easily
- Add specified `go` version for `codeql`

### Notes (If any)

- Test button has been improved for display GUI without data

### Related Issues

Close #60 

### Checklist:

#### Code Checklist:

-   [x] I have run the new code and ensure the change is work expected
-   [x] I have write/modify comments to important function & hard-to-understand code
-   [x] I have checked my code has no misspellings & no warnings
-   [x] I have checked that only essential code remains in this pull request

#### Documentation Checklist:

-   [x] I have add new feature description to README.md of this repository
-   [x] I have add/modify file description to README.md of the package (if any)

#### Testing Checklist:

-   [x] I have create new test case / test for new feature
-   [x] I have run all new & existing test and pass locally with my changes
